### PR TITLE
chore(vmd): refactor object accessor in a generic way

### DIFF
--- a/api/v2alpha1/virtual_machine_disk.go
+++ b/api/v2alpha1/virtual_machine_disk.go
@@ -57,3 +57,11 @@ const (
 	DiskNotReady          DiskPhase = "NotReady"
 	DiskPVCLost           DiskPhase = "PVCLost"
 )
+
+func (obj *VirtualMachineDisk) GetObjectMeta() metav1.ObjectMeta {
+	return obj.ObjectMeta
+}
+
+func (obj *VirtualMachineDisk) GetStatus() VirtualMachineDiskStatus {
+	return obj.Status
+}

--- a/pkg/controller/vmd_controller.go
+++ b/pkg/controller/vmd_controller.go
@@ -14,12 +14,15 @@ const (
 
 func NewVMDController(ctx context.Context, mgr manager.Manager, log logr.Logger) (controller.Controller, error) {
 	reconciler := &VMDReconciler{}
-	reconcilerCore := two_phase_reconciler.NewReconcilerCore[*VMDReconcilerState](reconciler, two_phase_reconciler.ReconcilerOptions{
-		Client:   mgr.GetClient(),
-		Recorder: mgr.GetEventRecorderFor(vmdControllerName),
-		Scheme:   mgr.GetScheme(),
-		Log:      log.WithName(vmdControllerName),
-	})
+	reconcilerCore := two_phase_reconciler.NewReconcilerCore[*VMDReconcilerState](
+		reconciler,
+		NewVMDReconcilerState,
+		two_phase_reconciler.ReconcilerOptions{
+			Client:   mgr.GetClient(),
+			Recorder: mgr.GetEventRecorderFor(vmdControllerName),
+			Scheme:   mgr.GetScheme(),
+			Log:      log.WithName(vmdControllerName),
+		})
 
 	c, err := controller.New(vmdControllerName, mgr, controller.Options{Reconciler: reconcilerCore})
 	if err != nil {

--- a/pkg/controller/vmd_reconciler_state.go
+++ b/pkg/controller/vmd_reconciler_state.go
@@ -4,60 +4,37 @@ import (
 	"context"
 	"fmt"
 	virtv2 "github.com/deckhouse/virtualization-controller/api/v2alpha1"
+	"github.com/deckhouse/virtualization-controller/pkg/sdk/framework/helper"
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 type VMDReconcilerState struct {
 	Client client.Client
-
-	VMD        *virtv2.VirtualMachineDisk
-	VMDMutated *virtv2.VirtualMachineDisk
-	DV         *cdiv1.DataVolume
-	Result     *reconcile.Result
+	VMD    *helper.Resource[*virtv2.VirtualMachineDisk, virtv2.VirtualMachineDiskStatus]
+	DV     *cdiv1.DataVolume
+	Result *reconcile.Result
 }
 
-func NewVMDReconcilerState(client client.Client) *VMDReconcilerState {
+func NewVMDReconcilerState(name types.NamespacedName, log logr.Logger, client client.Client) *VMDReconcilerState {
 	return &VMDReconcilerState{
 		Client: client,
+		VMD:    helper.NewResource[*virtv2.VirtualMachineDisk, virtv2.VirtualMachineDiskStatus](name, log, client),
 	}
 }
-
-// TODO: generics to generate parts of these methods especially resource-objects-related
 
 func (state *VMDReconcilerState) ApplySync(ctx context.Context, log logr.Logger) error {
-	if state.VMD == nil || state.VMDMutated == nil {
-		return nil
-	}
-	if !reflect.DeepEqual(state.VMD.ObjectMeta, state.VMDMutated.ObjectMeta) {
-		if !reflect.DeepEqual(state.VMD.Status, state.VMDMutated.Status) {
-			return fmt.Errorf("status update is not allowed in sync phase")
-		}
-
-		if err := state.Client.Update(ctx, state.VMDMutated); err != nil {
-			log.Error(err, "Unable to sync update VMD meta", "name", state.VMDMutated.Name)
-			return err
-		}
+	if err := state.VMD.UpdateMeta(ctx); err != nil {
+		return fmt.Errorf("unable to update VMD %q meta: %w", state.VMD.Name(), err)
 	}
 	return nil
 }
 
-// TODO: generic methods implementing following checks
 func (state *VMDReconcilerState) ApplyUpdateStatus(ctx context.Context, log logr.Logger) error {
-	if !reflect.DeepEqual(state.VMD.ObjectMeta, state.VMDMutated.ObjectMeta) {
-		return fmt.Errorf("meta update is not allowed in updateStatus phase")
-	}
-
-	if !reflect.DeepEqual(state.VMD.Status, state.VMDMutated.Status) {
-		if err := state.Client.Status().Update(ctx, state.VMDMutated); err != nil {
-			log.Error(err, "unable to update VMD status", "name", state.VMDMutated.Name)
-			return err
-		}
-	}
-	return nil
+	return state.VMD.UpdateStatus(ctx)
 }
 
 func (state *VMDReconcilerState) SetReconcilerResult(result *reconcile.Result) {
@@ -69,21 +46,19 @@ func (state *VMDReconcilerState) GetReconcilerResult() *reconcile.Result {
 }
 
 func (state *VMDReconcilerState) ShouldApplyUpdateStatus() bool {
-	return !reflect.DeepEqual(state.VMD.Status, state.VMDMutated.Status)
+	return state.VMD.IsStatusChanged()
 }
 
 func (state *VMDReconcilerState) Reload(ctx context.Context, req reconcile.Request, log logr.Logger, client client.Client) error {
-	vmd, err := FetchObject(ctx, req.NamespacedName, client, &virtv2.VirtualMachineDisk{})
-	if err != nil {
+	if err := state.VMD.Fetch(ctx, &virtv2.VirtualMachineDisk{}); err != nil {
 		return fmt.Errorf("unable to get %q: %w", req.NamespacedName, err)
 	}
-	if vmd == nil {
-		log.Info("Reconcile observe absent VMD: it may be deleted", "VMD", req.NamespacedName)
+	if !state.VMD.IsFound() {
+		log.Info("Reconcile observe an absent VMD: it may be deleted", "VMD", req.NamespacedName)
 		return nil
 	}
-	state.VMD = vmd
-	state.VMDMutated = vmd.DeepCopy()
 
+	var err error
 	state.DV, err = FetchObject(ctx, req.NamespacedName, client, &cdiv1.DataVolume{})
 	if err != nil {
 		return fmt.Errorf("unable to get %q: %w", req.NamespacedName, err)
@@ -92,5 +67,5 @@ func (state *VMDReconcilerState) Reload(ctx context.Context, req reconcile.Reque
 }
 
 func (state *VMDReconcilerState) ShouldReconcile() bool {
-	return state.VMD != nil
+	return state.VMD.IsFound()
 }

--- a/pkg/sdk/framework/helper/resource.go
+++ b/pkg/sdk/framework/helper/resource.go
@@ -1,0 +1,94 @@
+package helper
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Object[T, ST any] interface {
+	comparable
+	client.Object
+	DeepCopy() T
+	GetObjectMeta() metav1.ObjectMeta
+	GetStatus() ST
+}
+
+type Resource[T Object[T, ST], ST any] struct {
+	name       types.NamespacedName
+	ref        T
+	mutatedRef T
+
+	log    logr.Logger
+	client client.Client
+}
+
+func NewResource[T Object[T, ST], ST any](name types.NamespacedName, log logr.Logger, client client.Client) *Resource[T, ST] {
+	return &Resource[T, ST]{
+		name:   name,
+		log:    log,
+		client: client,
+	}
+}
+
+func (r *Resource[T, ST]) Name() types.NamespacedName {
+	return r.name
+}
+
+func (r *Resource[T, ST]) Fetch(ctx context.Context, inObj T) error {
+	obj, err := FetchObject(ctx, r.name, r.client, inObj)
+	if err != nil {
+		return err
+	}
+
+	r.ref = obj
+	r.mutatedRef = obj.DeepCopy()
+	return nil
+}
+
+func (r *Resource[T, ST]) IsFound() bool {
+	var empty T
+	return r.ref != empty
+}
+
+func (r *Resource[T, ST]) IsStatusChanged() bool {
+	return !reflect.DeepEqual(r.ref.GetStatus(), r.mutatedRef.GetStatus())
+}
+
+func (r *Resource[T, ST]) Read() T {
+	return r.ref
+}
+
+func (r *Resource[T, ST]) Write() T {
+	return r.mutatedRef
+}
+
+func (r *Resource[T, ST]) UpdateMeta(ctx context.Context) error {
+	if !r.IsFound() {
+		return nil
+	}
+	if !reflect.DeepEqual(r.ref.GetObjectMeta(), r.mutatedRef.GetObjectMeta()) {
+		if !reflect.DeepEqual(r.ref.GetStatus(), r.mutatedRef.GetStatus()) {
+			return fmt.Errorf("status update is not allowed in the meta updater")
+		}
+		return r.client.Update(ctx, r.mutatedRef)
+	}
+	return nil
+}
+
+func (r *Resource[T, ST]) UpdateStatus(ctx context.Context) error {
+	if !r.IsFound() {
+		return nil
+	}
+	if !reflect.DeepEqual(r.ref.GetObjectMeta(), r.mutatedRef.GetObjectMeta()) {
+		return fmt.Errorf("meta update is not allowed in the status updater")
+	}
+	if !reflect.DeepEqual(r.ref.GetStatus(), r.mutatedRef.GetStatus()) {
+		return r.client.Status().Update(ctx, r.mutatedRef)
+	}
+	return nil
+}

--- a/pkg/sdk/framework/helper/util.go
+++ b/pkg/sdk/framework/helper/util.go
@@ -1,0 +1,20 @@
+package helper
+
+import (
+	"context"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func FetchObject[T client.Object](ctx context.Context, key types.NamespacedName, client client.Client, obj T) (T, error) {
+	if err := client.Get(ctx, key, obj); err != nil {
+		var empty T
+		if k8serrors.IsNotFound(err) {
+			return empty, nil
+		}
+		return empty, err
+	}
+	return obj, nil
+}

--- a/pkg/sdk/framework/two_phase_reconciler/reconciler_state.go
+++ b/pkg/sdk/framework/two_phase_reconciler/reconciler_state.go
@@ -3,9 +3,12 @@ package two_phase_reconciler
 import (
 	"context"
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+type ReconcilerStateFactory[T ReconcilerState] func(name types.NamespacedName, log logr.Logger, client client.Client) T
 
 type ReconcilerState interface {
 	ReconcilerStateApplier

--- a/pkg/sdk/framework/two_phase_reconciler/two_phase_reconciler.go
+++ b/pkg/sdk/framework/two_phase_reconciler/two_phase_reconciler.go
@@ -11,5 +11,4 @@ type TwoPhaseReconciler[T ReconcilerState] interface {
 	SetupController(ctx context.Context, mgr manager.Manager, ctr controller.Controller) error
 	Sync(ctx context.Context, req reconcile.Request, state T, opts ReconcilerOptions) error
 	UpdateStatus(ctx context.Context, req reconcile.Request, state T, opts ReconcilerOptions) error
-	NewReconcilerState(opts ReconcilerOptions) T
 }


### PR DESCRIPTION
- Read/mutate operations are going throgh object accessor.
- Use update-meta or update-status methods to write changed object state.
- Minor refactor of sdk/framework/two_phase_reconciler.