### PR TITLE
fix(vmd): fix VMD creates several DV&PVCs instead of just one

### DIFF
--- a/api/v2alpha1/data_source.go
+++ b/api/v2alpha1/data_source.go
@@ -2,10 +2,23 @@ package v2alpha1
 
 // TODO: more fields from the CRD
 type DataSource struct {
-	Type string          `json:"type"`
+	Type DataSourceType  `json:"type"`
 	HTTP *DataSourceHTTP `json:"http,omitempty"`
 }
 
 type DataSourceHTTP struct {
 	URL string `json:"url"`
 }
+
+type DataSourceType string
+
+const (
+	DataSourceTypeHTTP                       DataSourceType = "HTTP"
+	DataSourceTypeContainerImage             DataSourceType = "ContainerImage"
+	DataSourceTypeVirtualMachineImage        DataSourceType = "VirtualMachineImage"
+	DataSourceTypeClusterVirtualMachineImage DataSourceType = "ClusterVirtualMachineImage"
+	DataSourceTypeVirtualMachineDisk         DataSourceType = "VirtualMachineDisk"
+	DataSourceTypeVirtualMachineDiskSnapshot DataSourceType = "VirtualMachineDiskSnapshot"
+	DataSourceTypePersistentVolumeClaim      DataSourceType = "PersistentVolumeClaim"
+	DataSourceTypeUpload                     DataSourceType = "Upload"
+)

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -275,7 +275,6 @@ func GetDefaultStorageClass(ctx context.Context, client client.Client) (*storage
 	return nil, nil
 }
 
-
 //// GetDefaultPodResourceRequirements gets default pod resource requirements from cdi config status
 //func GetDefaultPodResourceRequirements(client client.Client) (*corev1.ResourceRequirements, error) {
 //	cdiconfig := &cdiv1.CDIConfig{}
@@ -453,7 +452,7 @@ type getSource interface {
 
 // GetSource returns the source string which determines the type of source. If no source or invalid source found, default to http
 func GetSource(obj getSource) string {
-	srcType := obj.GetDataSource().Type
+	srcType := string(obj.GetDataSource().Type)
 	switch srcType {
 	case
 		SourceHTTP,

--- a/pkg/controller/vmd_controller.go
+++ b/pkg/controller/vmd_controller.go
@@ -19,6 +19,7 @@ func NewVMDController(ctx context.Context, mgr manager.Manager, log logr.Logger)
 		NewVMDReconcilerState,
 		two_phase_reconciler.ReconcilerOptions{
 			Client:   mgr.GetClient(),
+			Cache:    mgr.GetCache(),
 			Recorder: mgr.GetEventRecorderFor(vmdControllerName),
 			Scheme:   mgr.GetScheme(),
 			Log:      log.WithName(vmdControllerName),

--- a/pkg/controller/vmd_reconciler_state.go
+++ b/pkg/controller/vmd_reconciler_state.go
@@ -3,14 +3,14 @@ package controller
 import (
 	"context"
 	"fmt"
-	"github.com/deckhouse/virtualization-controller/pkg/util"
-	corev1 "k8s.io/api/core/v1"
-
 	virtv2 "github.com/deckhouse/virtualization-controller/api/v2alpha1"
 	"github.com/deckhouse/virtualization-controller/pkg/sdk/framework/helper"
+	"github.com/deckhouse/virtualization-controller/pkg/util"
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -25,10 +25,10 @@ type VMDReconcilerState struct {
 	PersistentVolumeClaimName types.NamespacedName
 }
 
-func NewVMDReconcilerState(name types.NamespacedName, log logr.Logger, client client.Client) *VMDReconcilerState {
+func NewVMDReconcilerState(name types.NamespacedName, log logr.Logger, client client.Client, cache cache.Cache) *VMDReconcilerState {
 	return &VMDReconcilerState{
 		Client: client,
-		VMD:    helper.NewResource[*virtv2.VirtualMachineDisk, virtv2.VirtualMachineDiskStatus](name, log, client),
+		VMD:    helper.NewResource[*virtv2.VirtualMachineDisk, virtv2.VirtualMachineDiskStatus](name, log, client, cache, &virtv2.VirtualMachineDisk{}),
 	}
 }
 
@@ -40,7 +40,26 @@ func (state *VMDReconcilerState) ApplySync(ctx context.Context, log logr.Logger)
 }
 
 func (state *VMDReconcilerState) ApplyUpdateStatus(ctx context.Context, log logr.Logger) error {
-	return state.VMD.UpdateStatus(ctx)
+	log.V(2).Info("VMDReconcilerState.ApplyUpdateStatus before", "VMD.Status", state.VMD.Changed().Status, "state.PersistentVolumeClaimName", state.PersistentVolumeClaimName)
+	if err := state.VMD.UpdateStatus(ctx); err != nil {
+		return err
+	}
+	log.V(2).Info("VMDReconcilerState.ApplyUpdateStatus after", "VMD.Status", state.VMD.Changed().Status, "state.PersistentVolumeClaimName", state.PersistentVolumeClaimName)
+
+	// FIXME: remove after some testing
+	//{
+	//	obj := &virtv2.VirtualMachineDisk{}
+	//	err := state.Client.Get(ctx, state.VMD.Name(), obj)
+	//	log.V(2).Info("EXTRA GET", "err", err, "obj", obj, "status", obj.Status)
+	//
+	//	time.Sleep(10 * time.Second)
+	//	obj2 := &virtv2.VirtualMachineDisk{}
+	//	err = state.Client.Get(ctx, state.VMD.Name(), obj2)
+	//	log.V(2).Info("EXTRA GET 2", "err", err, "obj", obj2, "status", obj2.Status)
+	//}
+	//
+	//time.Sleep(60 * time.Second)
+	return nil
 }
 
 func (state *VMDReconcilerState) SetReconcilerResult(result *reconcile.Result) {
@@ -56,33 +75,32 @@ func (state *VMDReconcilerState) ShouldApplyUpdateStatus() bool {
 }
 
 func (state *VMDReconcilerState) Reload(ctx context.Context, req reconcile.Request, log logr.Logger, client client.Client) error {
-	log.Info("VMD State Reload", "DV", state.DV)
-	if err := state.VMD.Fetch(ctx, &virtv2.VirtualMachineDisk{}); err != nil {
+	if err := state.VMD.Fetch(ctx); err != nil {
 		return fmt.Errorf("unable to get %q: %w", req.NamespacedName, err)
 	}
-	if !state.VMD.IsFound() {
+	if state.VMD.IsEmpty() {
 		log.Info("Reconcile observe an absent VMD: it may be deleted", "VMD", req.NamespacedName)
 		return nil
 	}
 
-	log.Info("VMD State Reload", "status pvc", state.VMD.Read().Status.PersistentVolumeClaimName, "state pvc", state.PersistentVolumeClaimName, "isEmpty", util.IsEmpty(state.PersistentVolumeClaimName))
+	log.V(2).Info("VMD State Reload", "status pvc", state.VMD.Current().Status.PersistentVolumeClaimName, "state pvc", state.PersistentVolumeClaimName, "isEmpty", util.IsEmpty(state.PersistentVolumeClaimName))
 
-	if util.IsEmpty(state.PersistentVolumeClaimName) && state.VMD.Read().Status.PersistentVolumeClaimName != "" {
+	if state.VMD.Current().Status.PersistentVolumeClaimName != "" {
+		log.V(2).Info("VMD State Reload", "restore pvc name", state.VMD.Current().Status.PersistentVolumeClaimName)
+
 		state.PersistentVolumeClaimName = types.NamespacedName{
-			Name:      state.VMD.Read().Status.PersistentVolumeClaimName,
+			Name:      state.VMD.Current().Status.PersistentVolumeClaimName,
 			Namespace: req.Namespace,
 		}
-	}
 
-	if !util.IsEmpty(state.PersistentVolumeClaimName) {
 		var err error
 		state.DV, err = helper.FetchObject(ctx, state.PersistentVolumeClaimName, client, &cdiv1.DataVolume{})
 		if err != nil {
 			return fmt.Errorf("unable to get DV %q: %w", state.PersistentVolumeClaimName, err)
 		}
 
-		// FIXME: This is happening: dv is nil here, why??
-		log.Info("VMD State Reload", "DV", state.DV)
+		// FIXME: This is happening: dv is nil here, why?? Answer: probably because of client cache.
+		log.V(2).Info("VMD State Reload", "DV", state.DV)
 
 		state.PVC, err = helper.FetchObject(ctx, state.PersistentVolumeClaimName, client, &corev1.PersistentVolumeClaim{})
 		if err != nil {
@@ -94,5 +112,5 @@ func (state *VMDReconcilerState) Reload(ctx context.Context, req reconcile.Reque
 }
 
 func (state *VMDReconcilerState) ShouldReconcile() bool {
-	return state.VMD.IsFound()
+	return !state.VMD.IsEmpty()
 }

--- a/pkg/sdk/framework/two_phase_reconciler/reconciler_state.go
+++ b/pkg/sdk/framework/two_phase_reconciler/reconciler_state.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-type ReconcilerStateFactory[T ReconcilerState] func(name types.NamespacedName, log logr.Logger, client client.Client) T
+type ReconcilerStateFactory[T ReconcilerState] func(name types.NamespacedName, log logr.Logger, client client.Client, cache cache.Cache) T
 
 type ReconcilerState interface {
 	ReconcilerStateApplier


### PR DESCRIPTION
Bug related to the client.Client and cache.Cache nuances: client.Get() just after client.Status().Update() receive an old inactual object status. Furthermore client.Get() in next reconcile cycle after client.Status().Update() in the previous reconcile cycle may receive an old inactual object status if called within seconds.

Current solution is to call client.Update just after client.Status.Update at framework/helper/resource.Resource::UpdateStatus level