### PR TITLE
chore(framework): refactor helper.Resource a bit

### DIFF
--- a/api/v2alpha1/virtual_machine_disk.go
+++ b/api/v2alpha1/virtual_machine_disk.go
@@ -59,11 +59,3 @@ const (
 	DiskNotReady          DiskPhase = "NotReady"
 	DiskPVCLost           DiskPhase = "PVCLost"
 )
-
-func (obj *VirtualMachineDisk) GetObjectMeta() metav1.ObjectMeta {
-	return obj.ObjectMeta
-}
-
-func (obj *VirtualMachineDisk) GetStatus() VirtualMachineDiskStatus {
-	return obj.Status
-}

--- a/pkg/controller/vmd_reconciler_state.go
+++ b/pkg/controller/vmd_reconciler_state.go
@@ -17,6 +17,7 @@ import (
 type VMDReconcilerState struct {
 	Client client.Client
 	VMD    *helper.Resource[*virtv2.VirtualMachineDisk, virtv2.VirtualMachineDiskStatus]
+	//PVC    *helper.Resource[*corev1.PersistentVolumeClaim, corev1.PersistentVolumeClaimStatus]
 	DV     *cdiv1.DataVolume
 	PVC    *corev1.PersistentVolumeClaim
 	Result *reconcile.Result
@@ -25,7 +26,11 @@ type VMDReconcilerState struct {
 func NewVMDReconcilerState(name types.NamespacedName, log logr.Logger, client client.Client, cache cache.Cache) *VMDReconcilerState {
 	return &VMDReconcilerState{
 		Client: client,
-		VMD:    helper.NewResource[*virtv2.VirtualMachineDisk, virtv2.VirtualMachineDiskStatus](name, log, client, cache, &virtv2.VirtualMachineDisk{}),
+		VMD: helper.NewResource(
+			name, log, client, cache,
+			func() *virtv2.VirtualMachineDisk { return &virtv2.VirtualMachineDisk{} },
+			func(obj *virtv2.VirtualMachineDisk) virtv2.VirtualMachineDiskStatus { return obj.Status },
+		),
 	}
 }
 


### PR DESCRIPTION
Eliminate GetStatus method from helper.Object interface requirement, use getter method instead.

This change allows usage of helper.Resource with most core resources (PVC for example).